### PR TITLE
onSetAfter delta argument

### DIFF
--- a/README.md
+++ b/README.md
@@ -199,9 +199,14 @@ myState.set({ age: 29 });
 state.get(); // { age: 29, lastUpdated: 1571291829316 }
 ```
 
-#### .onSetAfter(state) 
+#### .onSetAfter(newState, delta) 
 
 Do side-effect things after `set` is called.
+
+**Args**
+
+- `newState` - new state
+- `delta` - new state passed in to `.set()`. This helps us perform specific operations based on the delta properties.
 
 ```javascript
 class MyState extends SimpleState {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@geoctrl/simple-state",
-  "version": "1.0.4",
+  "version": "1.0.5",
   "main": "build/index.js",
   "author": "@geoctrl",
   "license": "MIT",

--- a/src/simple-state.js
+++ b/src/simple-state.js
@@ -26,7 +26,7 @@ export default class SimpleState {
       this.state = append
         ? Object.assign({}, this.state, state)
         : Object.assign({}, state);
-      this.onSetAfter(this.state);
+      this.onSetAfter(this.state, newState);
       this.__emitter.next(prevState, this.state);
     } else {
       this.__emitter.error(new TypeError(`[${this.constructor.name}] set(state) - "state" must be an object`));


### PR DESCRIPTION
`onSetAfter` now passes a second argument `delta`. This helps us perform specific operations based on the delta properties:

```javascript
// somewhere in the app:
myState.set({ show: false });
```

```javascript
class MyState extends SimpleState {
  onSetAfter = (newState, delta) => {
    if (delta.hasOwnProperty('show')) {
      // do things
    }
  }
}
export myState = new MyState();
```